### PR TITLE
Se modifico el boton de reservar turno que te lleva a error 404

### DIFF
--- a/src/components/views/Inicio.jsx
+++ b/src/components/views/Inicio.jsx
@@ -67,7 +67,7 @@ const Inicio = () => {
                 variant="primary"
                 className="px-4 py-3 rounded-4 fw-bolder"
                 as={Link}
-                to={"/login"}
+                to={"*"}
               >
                 Reservar Turno
               </Button>


### PR DESCRIPTION
@herreranicolas Corregí el botón de reserva de turnos en la pagina principal para que te lleve a error 404